### PR TITLE
Redirect custom domain to slack

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,18 @@
+{
+  "hosting": {
+    "public": "public",
+    "ignore": [
+      "firebase.json",
+      "**/.*",
+      "**/node_modules/**"
+    ],
+    "redirects": [
+      {
+        "source": "/**",
+        "destination": "http://radiateos.slack.com/oauth?client_id=9434476356342.9461660641456&scope=app_mentions%3Aread%2Cbookmarks%3Aread%2Ccalls%3Aread%2Ccanvases%3Awrite%2Cchannels%3Ahistory%2Cassistant%3Awrite%2Ccanvases%3Aread%2Cchannels%3Aread%2Cchannels%3Awrite.invites%2Cchannels%3Ajoin%2Cbookmarks%3Awrite%2Ccalls%3Awrite%2Cchat%3Awrite%2Cchannels%3Awrite.topic%2Cchannels%3Amanage%2Cincoming-webhook&user_scope=admin%2Cadmin.barriers%3Aread&redirect_uri=&state=&granular_bot_scope=1&single_channel=0&install_redirect=&tracked=1&user_default=0&team=",
+        "type": 301
+      }
+    ]
+  }
+}
+

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Redirecting…</title>
+    <meta http-equiv="refresh" content="0;url=http://radiateos.slack.com/oauth?client_id=9434476356342.9461660641456&scope=app_mentions%3Aread%2Cbookmarks%3Aread%2Ccalls%3Aread%2Ccanvases%3Awrite%2Cchannels%3Ahistory%2Cassistant%3Awrite%2Ccanvases%3Aread%2Cchannels%3Aread%2Cchannels%3Awrite.invites%2Cchannels%3Ajoin%2Cbookmarks%3Awrite%2Ccalls%3Awrite%2Cchat%3Awrite%2Cchannels%3Awrite.topic%2Cchannels%3Amanage%2Cincoming-webhook&user_scope=admin%2Cadmin.barriers%3Aread&redirect_uri=&state=&granular_bot_scope=1&single_channel=0&install_redirect=&tracked=1&user_default=0&team=" />
+  </head>
+  <body>
+    <p>Redirecting to Slack…</p>
+  </body>
+  </html>
+


### PR DESCRIPTION
Configure Firebase Hosting to 301 redirect all traffic from `redseaportal.com` to the provided Slack OAuth URL.

---
<a href="https://cursor.com/background-agent?bcId=bc-7cb57527-1074-4d5d-9f0f-5c3229720122">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7cb57527-1074-4d5d-9f0f-5c3229720122">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

