### PR TITLE
Figure out task independently

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,8 @@ replay_pid*
 
 # Kotlin Gradle plugin data, see https://kotlinlang.org/docs/whatsnew20.html#new-directory-for-kotlin-data-in-gradle-projects
 .kotlin/
+ 
+# Local Slack secrets/tokens
+slack/tokens.json
+slack/.env.local
+slack/.env

--- a/slack/README.md
+++ b/slack/README.md
@@ -1,0 +1,33 @@
+### RadiateOS Slack OAuth helper
+
+This folder contains a minimal, dependency-free Slack OAuth setup to connect RadiateOS to your Slack workspace.
+
+#### 1) Create a Slack app
+- Create an app in the Slack API dashboard.
+- Add a Redirect URL: `http://localhost:4321/slack/oauth/callback` (or set a custom port and update your app accordingly).
+- Add Bot Token Scopes to match your needs. Defaults used here:
+  - `app_mentions:read`, `channels:history`, `channels:read`, `chat:write`, `files:read`, `files:write`, `groups:read`, `users:read`.
+
+#### 2) Run the OAuth flow
+Export your credentials and start the flow:
+```bash
+export SLACK_CLIENT_ID=xxx
+export SLACK_CLIENT_SECRET=yyy
+# Optional overrides:
+# export SLACK_REDIRECT_PORT=4321
+# export SLACK_SCOPES="channels:history,channels:read,chat:write,files:read,files:write,groups:read,users:read,app_mentions:read"
+
+bash slack/start_oauth.sh
+```
+
+When finished, tokens are saved to `slack/tokens.json`.
+
+#### 3) Send a test message
+```bash
+bash slack/post_message.sh <channel-id> "Hello from RadiateOS"
+```
+
+#### Notes
+- Only standard library is used in `oauth_server.py`.
+- The scripts are safe to run on Linux and macOS; Windows WSL should also work.
+

--- a/slack/oauth_server.py
+++ b/slack/oauth_server.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""
+Minimal Slack OAuth v2 callback server.
+
+Usage:
+  Environment variables expected (typically exported by start_oauth.sh):
+    - SLACK_CLIENT_ID
+    - SLACK_CLIENT_SECRET
+    - SLACK_REDIRECT_PORT (optional, default: 4321)
+    - SLACK_OAUTH_STATE (expected state value)
+
+Starts a small HTTP server to handle the OAuth redirect at:
+  http://localhost:<port>/slack/oauth/callback
+
+On success, saves tokens to slack/tokens.json and exits.
+Only standard library is used.
+"""
+
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.parse import urlparse, parse_qs
+from urllib.request import Request, urlopen
+from urllib.parse import urlencode
+import json
+import os
+import sys
+import threading
+
+
+def _html_page(title: str, body: str) -> bytes:
+    return f"""
+<!doctype html>
+<html lang=\"en\">
+<head>
+  <meta charset=\"utf-8\">
+  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">
+  <title>{title}</title>
+  <style>
+    body {{ font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif; margin: 40px; }}
+    .card {{ max-width: 720px; margin: auto; padding: 24px; border: 1px solid #e3e3e3; border-radius: 10px; }}
+    h1 {{ font-size: 1.25rem; margin-top: 0; }}
+    code {{ background: #f6f8fa; padding: 2px 6px; border-radius: 6px; }}
+  </style>
+  </head>
+<body>
+  <div class=\"card\">
+    <h1>{title}</h1>
+    <p>{body}</p>
+  </div>
+ </body>
+ </html>
+""".encode("utf-8")
+
+
+class SlackOAuthHandler(BaseHTTPRequestHandler):
+    # Silence default logging noise to stderr
+    def log_message(self, format, *args):  # noqa: N802 (BaseHTTPRequestHandler API)
+        sys.stdout.write("[oauth_server] " + (format % args) + "\n")
+
+    def do_GET(self):  # noqa: N802 (BaseHTTPRequestHandler API)
+        parsed = urlparse(self.path)
+        if parsed.path != "/slack/oauth/callback":
+            self.send_response(404)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.end_headers()
+            self.wfile.write(_html_page("Not found", "This endpoint is for Slack OAuth callback only."))
+            return
+
+        query = parse_qs(parsed.query)
+        code = (query.get("code") or [""])[0]
+        state = (query.get("state") or [""])[0]
+
+        expected_state = os.environ.get("SLACK_OAUTH_STATE", "")
+        client_id = os.environ.get("SLACK_CLIENT_ID")
+        client_secret = os.environ.get("SLACK_CLIENT_SECRET")
+        port = int(os.environ.get("SLACK_REDIRECT_PORT", "4321"))
+        redirect_uri = f"http://localhost:{port}/slack/oauth/callback"
+
+        if not code:
+            self.send_response(400)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.end_headers()
+            self.wfile.write(_html_page("Missing code", "Slack did not include an OAuth code."))
+            return
+
+        if not expected_state or state != expected_state:
+            self.send_response(400)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.end_headers()
+            self.wfile.write(_html_page("Invalid state", "The state parameter did not match. Please restart the flow."))
+            return
+
+        if not client_id or not client_secret:
+            self.send_response(500)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.end_headers()
+            self.wfile.write(_html_page("Server misconfigured", "Missing SLACK_CLIENT_ID or SLACK_CLIENT_SECRET."))
+            return
+
+        # Exchange code for token
+        token_endpoint = "https://slack.com/api/oauth.v2.access"
+        payload = {
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "code": code,
+            "redirect_uri": redirect_uri,
+        }
+
+        try:
+            encoded = urlencode(payload).encode("utf-8")
+            req = Request(token_endpoint, data=encoded, method="POST")
+            req.add_header("Content-Type", "application/x-www-form-urlencoded")
+            with urlopen(req, timeout=20) as resp:
+                body = resp.read()
+            data = json.loads(body.decode("utf-8"))
+        except Exception as exc:  # noqa: BLE001
+            self.send_response(502)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.end_headers()
+            self.wfile.write(_html_page("OAuth failed", f"Exchange error: {exc}"))
+            return
+
+        if not data.get("ok"):
+            self.send_response(400)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.end_headers()
+            self.wfile.write(_html_page("Slack error", json.dumps(data, indent=2)))
+            return
+
+        # Persist tokens
+        os.makedirs(os.path.join(os.getcwd(), "slack"), exist_ok=True)
+        tokens_path = os.path.join(os.getcwd(), "slack", "tokens.json")
+        with open(tokens_path, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2, sort_keys=True)
+
+        # Inform the user and shutdown the server
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.end_headers()
+        self.wfile.write(
+            _html_page(
+                "RadiateOS Slack connected",
+                "Authorization complete. You can close this window and return to the terminal.",
+            )
+        )
+
+        # Shutdown server on a separate thread to avoid blocking
+        threading.Thread(target=self.server.shutdown, daemon=True).start()
+
+
+def main() -> None:
+    port = int(os.environ.get("SLACK_REDIRECT_PORT", "4321"))
+    addr = ("", port)
+    httpd = HTTPServer(addr, SlackOAuthHandler)
+    print(f"[oauth_server] Listening on http://localhost:{port}/slack/oauth/callback")
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        httpd.server_close()
+        print("[oauth_server] Stopped.")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/slack/post_message.sh
+++ b/slack/post_message.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TOKENS_FILE="$(dirname "$0")/tokens.json"
+if [[ ! -f "$TOKENS_FILE" ]]; then
+  echo "[error] tokens.json not found. Run slack/start_oauth.sh first." >&2
+  exit 1
+fi
+
+BOT_TOKEN=$(python3 - "$TOKENS_FILE" <<'PY'
+import json, sys
+path = sys.argv[1]
+with open(path, 'r', encoding='utf-8') as f:
+    data = json.load(f)
+print(data.get('access_token') or data.get('bot_access_token') or '')
+PY
+)
+
+if [[ -z "${BOT_TOKEN:-}" ]]; then
+  echo "[error] Could not read bot token from tokens.json" >&2
+  exit 1
+fi
+
+CHANNEL="${1:-}"
+TEXT="${2:-}"
+if [[ -z "$CHANNEL" || -z "$TEXT" ]]; then
+  echo "Usage: $0 <channel-id> <text>" >&2
+  exit 1
+fi
+
+payload=$(python3 - <<PY
+import json, sys
+print(json.dumps({"channel": sys.argv[1], "text": sys.argv[2]}))
+PY
+"$CHANNEL" "$TEXT")
+
+curl -sS -X POST "https://slack.com/api/chat.postMessage" \
+  -H "Authorization: Bearer ${BOT_TOKEN}" \
+  -H "Content-Type: application/json; charset=utf-8" \
+  --data "$payload" | python3 -m json.tool
+

--- a/slack/start_oauth.sh
+++ b/slack/start_oauth.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Minimal Slack OAuth starter.
+# Requires: SLACK_CLIENT_ID, SLACK_CLIENT_SECRET
+# Optional: SLACK_SCOPES (comma-separated), SLACK_USER_SCOPES (comma-separated), SLACK_REDIRECT_PORT
+
+if [[ -z "${SLACK_CLIENT_ID:-}" || -z "${SLACK_CLIENT_SECRET:-}" ]]; then
+  echo "[error] SLACK_CLIENT_ID and SLACK_CLIENT_SECRET must be set in the environment." >&2
+  exit 1
+fi
+
+PORT="${SLACK_REDIRECT_PORT:-4321}"
+STATE="$(head -c 16 /dev/urandom | xxd -p)"
+export SLACK_OAUTH_STATE="$STATE"
+
+REDIRECT_URI="http://localhost:${PORT}/slack/oauth/callback"
+SCOPES="${SLACK_SCOPES:-channels:history,channels:read,chat:write,files:read,files:write,groups:read,users:read,app_mentions:read}"
+USER_SCOPES="${SLACK_USER_SCOPES:-}"
+
+echo "[info] Starting local OAuth callback server on port ${PORT}..."
+python3 "$(dirname "$0")/oauth_server.py" &
+SERVER_PID=$!
+
+cleanup() {
+  if kill -0 "$SERVER_PID" >/dev/null 2>&1; then
+    kill "$SERVER_PID" || true
+  fi
+}
+trap cleanup EXIT INT TERM
+
+AUTH_URL="https://slack.com/oauth/v2/authorize?client_id=${SLACK_CLIENT_ID}&scope=${SCOPES}&user_scope=${USER_SCOPES}&redirect_uri=${REDIRECT_URI}&state=${STATE}"
+
+echo "[info] Opening Slack authorization URL..."
+echo "[info] If your desktop doesn't open, paste into a browser:"
+echo "${AUTH_URL}"
+echo "[info] Ensure the Slack app has this Redirect URL configured: ${REDIRECT_URI}"
+
+if command -v xdg-open >/dev/null 2>&1; then
+  xdg-open "$AUTH_URL" || true
+elif command -v open >/dev/null 2>&1; then
+  open "$AUTH_URL" || true
+fi
+
+echo "[info] Waiting for OAuth to complete..."
+wait "$SERVER_PID" || true
+
+TOKENS_FILE="$(dirname "$0")/tokens.json"
+if [[ -f "$TOKENS_FILE" ]]; then
+  echo "[success] Tokens saved to slack/tokens.json"
+  exit 0
+else
+  echo "[error] OAuth did not complete successfully (no tokens.json)." >&2
+  exit 2
+fi
+


### PR DESCRIPTION
Add a self-contained Slack OAuth helper with scripts and a local Python server to simplify token acquisition and message posting.

---
<a href="https://cursor.com/background-agent?bcId=bc-3d9052a9-713a-4f92-8b2c-9034772fd195">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3d9052a9-713a-4f92-8b2c-9034772fd195">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

